### PR TITLE
Depend on socksipython>=2.0.15 in PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='Python implementation of the PageKite remote front-end protocols.'
 arch=('any')
 url='http://pagekite.org'
 license=('GPL')
-depends=('python2' 'python2-setuptools' 'python2-socksipychain')
+depends=('python2' 'python2-setuptools' 'python2-socksipychain>=2.0.15')
 provides=('pagekite')
 conflicts=('python2-pagekite')
 options=(!emptydirs zipman)


### PR DESCRIPTION
If you don't depend on a specific version, a user (e.g. I) of a previous version upgrading to the latest, will be left with outdated socksipython, not understanding why pagekite would not connect.
